### PR TITLE
Docker implementation review and fix

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,73 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ 'v*', 'release-*' ]
+  workflow_dispatch: {}
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: camoufox
+            file: Docker/Dockerfile.camoufox
+            latest: true
+          - name: rdp
+            file: Docker/Dockerfile
+            latest: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for cross-building)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        run: |
+          REPO_LOWER=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
+          TAGS="${REGISTRY}/${REPO_LOWER}:${{ matrix.name }}-${GITHUB_SHA}"
+          TAGS+="\n${REGISTRY}/${REPO_LOWER}:${{ matrix.name }}"
+          if [ "${{ matrix.latest }}" = "true" ]; then
+            TAGS+="\n${REGISTRY}/${REPO_LOWER}:latest"
+          fi
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$TAGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,8 +5,7 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV TZ=America/New_York
-ENV RUN_API_SOLVER=false
-
+ENV RUN_API_SOLVER=true
 
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -33,19 +32,20 @@ RUN apt-get update && \
     xfce4-terminal \
     python3-pip \
     ca-certificates \
-    xvfb
-
-RUN apt remove -y light-locker xscreensaver && \
+    xvfb && \
+    apt remove -y light-locker xscreensaver && \
     apt autoremove -y && \
     rm -rf /var/cache/apt /var/lib/apt/lists
 
-RUN apt-get update && \
-    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    apt-get install -y ./google-chrome-stable_current_amd64.deb && \
-    rm ./google-chrome-stable_current_amd64.deb
+# Set workdir and copy app
+WORKDIR /app
+COPY requirements.txt /app/
+RUN pip3 install --no-cache-dir -r requirements.txt --break-system-packages
+COPY . /app
 
-COPY ./run.sh /usr/bin/
+# Copy startup script
+COPY ./Docker/run.sh /usr/bin/run.sh
 RUN chmod +x /usr/bin/run.sh
 
-EXPOSE 3389
+EXPOSE 3389 5000
 ENTRYPOINT ["/usr/bin/run.sh"]

--- a/Docker/Dockerfile.camoufox
+++ b/Docker/Dockerfile.camoufox
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     wget \
+    xvfb \
+    xauth \
     libnss3 \
     libnspr4 \
     libatk1.0-0 \
@@ -43,4 +45,4 @@ COPY . /app
 
 EXPOSE 5000
 
-CMD ["bash", "-lc", "python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True"]
+CMD ["bash", "-lc", "xvfb-run -a python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless False"]

--- a/Docker/Dockerfile.camoufox
+++ b/Docker/Dockerfile.camoufox
@@ -1,0 +1,46 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# System dependencies commonly required by Playwright/Firefox-based browsers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libxrender1 \
+    libxtst6 \
+    libxshmfence1 \
+    libx11-6 \
+    libxext6 \
+    libgbm1 \
+    libgtk-3-0 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt \
+    && python -m camoufox fetch || true
+
+COPY . /app
+
+EXPOSE 5000
+
+CMD ["bash", "-lc", "python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True"]

--- a/Docker/entrypoint.camoufox.sh
+++ b/Docker/entrypoint.camoufox.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+
+# Ensure camoufox browser is available (best-effort)
+python -m camoufox fetch || true
+
+exec python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -56,25 +56,19 @@ if [ -n "$TZ" ]; then
     echo $TZ >/etc/timezone
 fi
 
-mkdir -p /root/Desktop
-
-cd /root/Desktop || {
-    echo "Failed to change directory to /root/Desktop"
+# Use application code copied into the image
+cd /app || {
+    echo "Failed to change directory to /app"
     exit 1
 }
-
-git clone https://github.com/Theyka/Turnstile-Solver.git
-cd Turnstile-Solver || {
-    echo "Failed to change directory to Turnstile-Solver"
-    exit 1
-}
-
-pip3 install -r requirements.txt --break-system-packages
 
 trap "stop_xrdp_services" SIGKILL SIGTERM SIGHUP SIGINT EXIT
 start_xrdp_services
 
-if [ "$RUN_API_SOLVER" = "true" ]; then
-    echo "Starting API solver in headful mode..."
-    xvfb-run -a python3 /root/Desktop/Turnstile-Solver/api_solver.py --browser_type chrome --host 0.0.0.0
+# Start API solver by default unless explicitly disabled
+if [ "${RUN_API_SOLVER}" = "false" ]; then
+    echo "RUN_API_SOLVER=false; not starting the API automatically."
+else
+    echo "Starting API solver (camoufox, headless) on 0.0.0.0:5000..."
+    exec python3 /app/api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True
 fi

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -69,6 +69,8 @@ start_xrdp_services
 if [ "${RUN_API_SOLVER}" = "false" ]; then
     echo "RUN_API_SOLVER=false; not starting the API automatically."
 else
+    echo "Ensuring Camoufox browser assets are available..."
+    python3 -m camoufox fetch || true
     echo "Starting API solver (camoufox, headless) on 0.0.0.0:5000..."
     exec python3 /app/api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True
 fi

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -71,6 +71,6 @@ if [ "${RUN_API_SOLVER}" = "false" ]; then
 else
     echo "Ensuring Camoufox browser assets are available..."
     python3 -m camoufox fetch || true
-    echo "Starting API solver (camoufox, headless) on 0.0.0.0:5000..."
-    exec python3 /app/api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --headless True
+    echo "Starting API solver (camoufox, headful via Xvfb) on 0.0.0.0:5000..."
+    exec xvfb-run -a python3 /app/api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000
 fi

--- a/README.md
+++ b/README.md
@@ -202,3 +202,146 @@ If the CAPTCHA is solved successfully, the server will respond with the followin
 Inspired by [Turnaround](https://github.com/Body-Alhoha/turnaround)
 Original code by [Theyka](https://github.com/Theyka/Turnstile-Solver)
 Changes by [Sexfrance](https://github.com/sexfrance)
+
+---
+
+## Comprehensive Documentation
+
+### Quickstart (Local)
+- Install Python 3.9+
+- Install dependencies and choose a browser (Camoufox recommended):
+  ```bash
+  pip install -r requirements.txt
+  python -m camoufox fetch
+  ```
+- Start API locally:
+  ```bash
+  python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000
+  ```
+- Test:
+  ```bash
+  curl 'http://localhost:5000/turnstile?url=https://example.com&sitekey=0x4AAAAAAA'
+  ```
+
+### Browser Options
+- Default: Camoufox (no custom user-agent needed for headful/headless)
+- Chromium/Chrome/Edge via Patchright:
+  ```bash
+  # Examples
+  python -m patchright install chromium
+  python -m patchright install msedge
+  # Chrome on Debian/Ubuntu (if not using Patchright):
+  wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  apt install -y ./google-chrome-stable_current_amd64.deb
+  rm ./google-chrome-stable_current_amd64.deb
+  ```
+- Note: For non-Camoufox headless, a custom `--useragent` is required.
+
+### API Reference
+- GET `/turnstile`
+  - Query params:
+    - `url` (required)
+    - `sitekey` (required)
+    - `action` (optional)
+    - `cdata` (optional)
+  - Returns: `{ "task_id": "uuid" }` with 202 Accepted on queueing
+- GET `/result`
+  - Query params:
+    - `id` (required, returned by `/turnstile`)
+  - Returns: `{ "value": "<token>", "elapsed_time": <seconds> }` on success or HTTP 422 with `CAPTCHA_FAIL` value
+
+Examples:
+```bash
+# Submit a task
+curl 'http://localhost:5000/turnstile?url=https://example.com&sitekey=0x4AAAAAAA'
+
+# Fetch result
+curl 'http://localhost:5000/result?id=<task_id>'
+```
+
+### Configuration (CLI flags)
+- `--headless` (bool, default False): Run browser headless. For Chromium/Chrome/Edge, a `--useragent` is required if headless.
+- `--useragent` (str, default None): Custom user agent.
+- `--debug` (bool, default False): Extra logging.
+- `--browser_type` (str, default camoufox): One of `chromium`, `chrome`, `msedge`, `camoufox`.
+- `--thread` (int, default 1): Number of concurrent browsers in the pool.
+- `--proxy` (bool, default False): Enable proxy usage (read from `proxies.txt`).
+- `--host` (str, default 127.0.0.1): Bind address.
+- `--port` (int, default 5000): API port.
+
+### Proxies
+- Enable with `--proxy True` and provide `proxies.txt` in the working directory.
+- Supported line formats (one per line):
+  - `http://ip:port`
+  - `socks5://ip:port`
+  - `http:ip:port:username:password`
+  - `socks5:ip:port:username:password`
+
+### Running with Docker (GHCR)
+Images are published to the GitHub Container Registry (GHCR) via CI.
+
+- Pull images:
+  ```bash
+  docker pull ghcr.io/<owner>/<repo>:camoufox   # API-first (recommended)
+  docker pull ghcr.io/<owner>/<repo>:latest     # Alias of camoufox
+  docker pull ghcr.io/<owner>/<repo>:rdp        # Legacy RDP-enabled image
+  ```
+
+- Run API-first (Camoufox):
+  ```bash
+  docker run -d \
+    --name turnstile_solver \
+    -p 5000:5000 \
+    -v $(pwd)/proxies.txt:/app/proxies.txt:ro \
+    -v $(pwd)/results.json:/app/results.json \
+    ghcr.io/<owner>/<repo>:camoufox
+  ```
+  - Starts API automatically on `0.0.0.0:5000`
+  - Contains a virtual display (Xvfb) for GUI needs
+
+- Run RDP image (optional):
+  ```bash
+  docker run -d \
+    --name turnstile_solver_rdp \
+    -p 3389:3389 -p 5000:5000 \
+    -e TZ=UTC \
+    -e RUN_API_SOLVER=true \
+    -v $(pwd)/proxies.txt:/app/proxies.txt:ro \
+    -v $(pwd)/results.json:/app/results.json \
+    ghcr.io/<owner>/<repo>:rdp
+  ```
+  - RDP: connect to `localhost:3389` (user `root`, pass `root`)
+  - API runs automatically via Xvfb; RDP is optional
+
+- Override CLI args (both images):
+  ```bash
+  docker run -d -p 5000:5000 ghcr.io/<owner>/<repo>:camoufox \
+    python api_solver.py --browser_type camoufox --host 0.0.0.0 --port 5000 --thread 2 --proxy True
+  ```
+
+### CI/CD (GitHub Actions → GHCR)
+- On push to `main`/`master`, tags (`v*`, `release-*`), or manual dispatch:
+  - Builds `Docker/Dockerfile.camoufox` (tags: `:camoufox`, `:latest`, `:camoufox-<sha>`)
+  - Builds `Docker/Dockerfile` (tags: `:rdp`, `:rdp-<sha>`)
+- Requires repository Actions workflow permission: “Read and write” to publish packages.
+
+### Networking & Ports
+- API listens on `:5000` in containers; expose/map with `-p 5000:5000`.
+- RDP image also exposes `:3389` for desktop access (optional).
+
+### Data & Persistence
+- `results.json` stores completed tasks; map it as a volume for persistence.
+- `proxies.txt` optional; map read-only if used.
+
+### Troubleshooting
+- Browser fails to launch:
+  - Ensure Camoufox fetched: `python -m camoufox fetch`
+  - In Docker, both images bundle Xvfb for GUI requirements.
+- Headless with Chromium/Chrome/Edge errors:
+  - Provide a `--useragent` or switch to Camoufox.
+- API not reachable in Docker:
+  - Confirm binding to `0.0.0.0` and port mapping `-p 5000:5000`.
+- Proxy errors:
+  - Verify `proxies.txt` format matches the documented formats.
+
+---

--- a/README.md
+++ b/README.md
@@ -120,20 +120,28 @@ A Python-based Turnstile solver using the patchright library, featuring multi-th
 ---
 
 ### 🐳 Docker Image
-#### Running the Container
-To start the container, use:
-- Change the TZ environment variable and ports to the correct one for yourself:
+#### Running the Container (API-first, no RDP)
+Build and run the API container that starts automatically on port 5000 using Camoufox by default:
+
 ```sh
-docker run -d -p 3389:3389 -p 5000:5000 -e TZ=Asia/Baku --name turnstile_solver theyka/turnstile_solver:latest
+# Build
+docker build -f Docker/Dockerfile.camoufox -t turnstile_solver:camoufox .
+
+# Run
+docker run -d --name turnstile_solver -p 5000:5000 turnstile_solver:camoufox
 ```
 
-#### Connecting to the Container
-1. Use an **RDP client** (like Windows Remote Desktop, Remmina, or FreeRDP)
-2. Connect to `localhost:3389`
-3. Login with the default user:
-   - **Username:** root
-   - **Password:** root
-4. After this, you can start the solver by navigating to the `Turnstile-Solver` folder.
+After the container starts, the API is available at `http://localhost:5000`.
+
+#### Legacy Desktop/RDP Container (optional)
+If you still want an RDP-enabled image:
+
+```sh
+docker build -f Docker/Dockerfile -t turnstile_solver:rdp .
+docker run -d -p 3389:3389 -p 5000:5000 -e TZ=Asia/Baku --name turnstile_solver turnstile_solver:rdp
+```
+
+You can connect via RDP to `localhost:3389` (user `root`, pass `root`), but this is no longer required to start the API. The API starts automatically on port 5000 and defaults to Camoufox.
 
 ---
 

--- a/api_solver.py
+++ b/api_solver.py
@@ -341,7 +341,7 @@ def parse_args():
     parser.add_argument('--headless', type=bool, default=False, help='Run the browser in headless mode, without opening a graphical interface. This option requires the --useragent argument to be set (default: False)')
     parser.add_argument('--useragent', type=str, default=None, help='Specify a custom User-Agent string for the browser. If not provided, the default User-Agent is used')
     parser.add_argument('--debug', type=bool, default=False, help='Enable or disable debug mode for additional logging and troubleshooting information (default: False)')
-    parser.add_argument('--browser_type', type=str, default='chromium', help='Specify the browser type for the solver. Supported options: chromium, chrome, msedge, camoufox (default: chromium)')
+    parser.add_argument('--browser_type', type=str, default='camoufox', help='Specify the browser type for the solver. Supported options: chromium, chrome, msedge, camoufox (default: camoufox)')
     parser.add_argument('--thread', type=int, default=1, help='Set the number of browser threads to use for multi-threaded mode. Increasing this will speed up execution but requires more resources (default: 1)')
     parser.add_argument('--proxy', type=bool, default=False, help='Enable proxy support for the solver (Default: False)')
     parser.add_argument('--host', type=str, default='127.0.0.1', help='Specify the IP address where the API solver runs. (Default: 127.0.0.1)')

--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ class TurnstileTester:
             return {}
 
 
-    async def run_api_server(self, debug=False, headless=False, useragent=None, browser_type="chromium", thread=1) -> None:
+    async def run_api_server(self, debug=False, headless=False, useragent=None, browser_type="camoufox", thread=1) -> None:
         """Run the API server with logging."""
         logger.info("Starting API server on http://localhost:5000")
         logger.info("API documentation available at http://localhost:5000/")


### PR DESCRIPTION
Refactor Docker setup to default to Camoufox and automatically run the API solver without RDP.

The previous Docker implementation required users to connect via RDP to manually start the API solver, defaulted to Chrome, and cloned the repository at runtime. This PR addresses these issues by providing an API-first Docker image, exposing port 5000, setting Camoufox as the default browser, and streamlining the build process to copy the application at build time.

---
<a href="https://cursor.com/background-agent?bcId=bc-025c867e-3386-424e-85b4-f074cb05099e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-025c867e-3386-424e-85b4-f074cb05099e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

